### PR TITLE
Fix lineage-aware subsampling to correctly include foreign same-lineage context

### DIFF
--- a/src/backend/aspen/workflows/nextstrain_run/build_plugins/type_plugins.py
+++ b/src/backend/aspen/workflows/nextstrain_run/build_plugins/type_plugins.py
@@ -24,155 +24,156 @@ class TreeTypePlugin(BaseConfigPlugin):
             self.tree_build_level = "country"
         elif not location.location:
             self.tree_build_level = "division"
-        # Fill out country/division/location fields if the group has them,
-        # or remove those fields if they don't.
-        location_fields = ["country", "division", "location"]
-        location_values = []
-        for field in location_fields:
-            value = getattr(location, field)
-            if value:
-                build[field] = value
-                location_values.append(value)
-            else:
-                if build.get(field):
-                    del build[field]
+        else:
+            self.tree_build_level = "location"
+        build["location"] = str(location.location)
+        build["division"] = str(location.division)
+        build["country"] = str(location.country)
+        build["geo_group"] = location.geo_group
 
-        # NOTE: <TreeTypePlugin>.subsampling_scheme is used in 3 places:
-        #   - Its lowercase'd name is used to find a markdown file with an "about this tree" description
-        #   - It refers to a subsampling_scheme key in the mega nextstrain template
-        #   - It's title-case'd and included in the tree title as human-readable text
+        target_crowding = self.crowding_penalty * (
+            self.template_args.get("target_crowding", 2)
+        )
+        if target_crowding:
+            build["target_crowding"] = target_crowding
+
         build["subsampling_scheme"] = self.subsampling_scheme
 
-        # Update the tree's title with build type, location and date range.
-        # We always provide some form of end date in the title.
-        end_date = self._get_formatted_tree_end_date()
-        # We base format of title on whether we have a `filter_start_date`
-        if self.template_args.get("filter_start_date") is not None:
-            title_template = "{tree_type} tree for samples collected in {location} between {start_date} and {end_date}"
-            build["title"] = title_template.format(
-                tree_type=self.subsampling_scheme.title(),
-                location=", ".join(location_values),
-                start_date=dateparser.parse(
-                    self.template_args.get("filter_start_date")
-                ).strftime("%Y-%m-%d"),
-                end_date=end_date,
-            )
-        else:
-            title_template = "{tree_type} tree for samples collected in {location} up until {end_date}"
-            build["title"] = title_template.format(
-                tree_type=self.subsampling_scheme.title(),
-                location=", ".join(location_values),
-                end_date=end_date,
-            )
+        if self.template_args.get("filter_pango_lineages"):
+            build["filter_pango_lineages"] = self.template_args["filter_pango_lineages"]
 
-        if config.get("files"):
-            config["files"]["description"] = config["files"]["description"].format(
-                tree_type=self.subsampling_scheme.lower()
-            )
-        if config.get("priorities"):
-            config["priorities"]["crowding_penalty"] = self.crowding_penalty
+        # Filter samples by date. Ex: samples from the past 6 months.
+        # This is specific to the "aspen" build only.
+        build["filter_start_date"] = self.template_args.get("filter_start_date")
 
-    def _get_formatted_tree_end_date(self):
-        """Returns appropriate YYYY-MM-DD for tree's end date or "--" if none.
+        # Cherry-pick specific samples (aka "ids")
+        if self.template_args.get("filter_include_ids"):
+            build["include_ids"] = self.template_args["filter_include_ids"]
 
-        For tree titles, we want to always have an end date to display. If
-        the tree had a `filter_end_date` arg, we can use that. However, if no
-        filter arg was given for the end date, we use the implicit end date of
-        when the tree build was kicked off (from PhyloRun.start_datetime), as
-        the tree build process can only use samples up to the moment in time
-        when it was kicked off, so it's an implicit end date to samples.
+        # Filter samples by lineage. This is specific to the "aspen" build only.
+        if self.template_args.get("filter_pango_lineages"):
+            build["filter_pango_lineages"] = self.template_args["filter_pango_lineages"]
 
-        If there is no date available at all, we return "--" as an absolute
-        fall back. PhyloRun.start_datetime is not actually guaranteed at the DB
-        level, but all our code that creates runs always provides one (as of
-        Nov 2022, every single run has a start_datetime). The fall back is
-        provided just to code defensively in case something weird ever happens.
-        """
-        formatted_end_date = "--"  # safe default, should never happen
-        filter_end_date = self.template_args.get("filter_end_date")
-        if filter_end_date is not None:
-            formatted_end_date = dateparser.parse(filter_end_date).strftime("%Y-%m-%d")
-        else:
-            # `run_start_datetime` is a `context` kwarg, so not guaranteed
-            run_start_datetime = getattr(self, "run_start_datetime", None)
-            if run_start_datetime is not None:
-                formatted_end_date = run_start_datetime.strftime("%Y-%m-%d")
-            else:
-                print("WARNING -- Run missing a start_datetime. Default to '--'")
-        return formatted_end_date
+        # Filter samples by region. This is specific to the "aspen" build only.
+        if self.template_args.get("filter_regions"):
+            build["filter_regions"] = self.template_args["filter_regions"]
 
-    def update_config(self, config):
-        self._update_config_params(config)
+        # Filter samples by country. This is specific to the "aspen" build only.
+        if self.template_args.get("filter_countries"):
+            build["filter_countries"] = self.template_args["filter_countries"]
 
-        subsampling = config["subsampling"][self.subsampling_scheme]
-        self.run_type_config(config, subsampling)
-
-        # Remove unused subsampling schemes from our output file
-        config["subsampling"] = {self.subsampling_scheme: subsampling}
-
-    def run_type_config(self, config, subsampling):
-        raise NotImplementedError("base class doesn't implement this")
+        # Filter samples by division. This is specific to the "aspen" build only.
+        if self.template_args.get("filter_divisions"):
+            build["filter_divisions"] = self.template_args["filter_divisions"]
 
 
 class OverviewPlugin(TreeTypePlugin):
-    crowding_penalty = 0.1
+    crowding_penalty = 1.0
     tree_type = TreeType.OVERVIEW
     subsampling_scheme = "OVERVIEW"
 
     def run_type_config(self, config, subsampling):
-        if self.group.name == "Chicago Department of Public Health":
-            if "--query" in subsampling["group"]["query"]:  # SC2 format
-                subsampling["group"][
-                    "query"
-                ] = '''--query "((location == '{location}') & (division == '{division}')) | submitting_lab == 'RIPHL at Rush University Medical Center'"'''
-            else:  # MPX format
-                subsampling["group"]["query"] = (
-                    "("
-                    + subsampling["group"]["query"]
-                    + ") | submitting_lab == 'RIPHL at Rush University Medical Center'"
-                )
+        """
+        DATA we can use in this function:
+          config : the entire mega-template data structure, with build configs already updated by BaseNextstrainConfigBuilder.update_build()
+          subsampling : the subsampling scheme for *this build type only* (ex: mega_template["subsampling"]["OVERVIEW"])
+          self.subsampling_scheme : the value a few lines above
+          self.crowding_penalty : the value a few lines above
+          self.group : information about the group that this run is for (ex: self.group.name or self.group.default_tree_location)
+          self.num_sequences : the number of aspen samples written to our fasta input file
+          self.num_included_samples : the number of samples in include.txt (aspen + gisaid samples) for on-demand runs only
+
+        EXAMPLES SECTION:
+          Delete a group from a subsampling scheme:
+              del subsampling["international"]
+
+          Delete a setting from a group:
+              del subsampling["international"]["seq_per_group"]
+
+          Add a group to a subsampling scheme:
+              subsampling["my_new_group_name"] = {
+                  "group_by": "region",
+                  "max_sequences": 200,
+                  "query": '--query "(foo != {bar})"'
+              }
+
+          Add a setting to a group (this is the same as updating an existing setting!):
+              subsampling["international"]["mynewsetting"] = "mynewvalue"
+        """
+        # Adjust group sizes if we have a lot of samples.
+        root_max_sequences = 25
+        state_max_sequences = 500
+        country_max_sequences = 400
+        international_max_sequences = 100
+        if self.num_included_samples >= 250:
+            # For huge builds, just show the root, the local group, and some
+            # serial-sampling implemented in the subsampling config.
+            del subsampling["state"]
+            del subsampling["country"]
+            del subsampling["international"]
+
+        if self.template_args.get("target_crowding"):
+            # The crowding penalty increases the target number of sequences to
+            # prevent high sample density areas from over-crowding the tree
+            crowding_penalty = self.crowding_penalty
+            root_max_sequences *= crowding_penalty
+            country_max_sequences *= crowding_penalty
+            state_max_sequences *= crowding_penalty
+            international_max_sequences *= crowding_penalty
+
+        subsampling["root"]["max_sequences"] = root_max_sequences
+        subsampling["state"]["max_sequences"] = state_max_sequences
+        subsampling["country"]["max_sequences"] = country_max_sequences
+        subsampling["international"]["max_sequences"] = international_max_sequences
 
         # Handle sampling date & pango lineage filters
         apply_filters(config, subsampling, self.template_args)
 
-        # Update our sampling for state/country level builds if necessary
+        # Links the location, division, and country for country and division level
+        # sampling.
         update_subsampling_for_location(self.tree_build_level, subsampling)
-
-        # Update country and international max sequences.
-        if self.tree_build_level == "country":
-            subsampling["international"]["max_sequences"] = 1000
-        if self.tree_build_level == "division":
-            subsampling["country"]["max_sequences"] = 800
-            subsampling["international"]["max_sequences"] = 200
-
-        # If there aren't any selected samples
-        # Either due to being a scheduled run or no user selection
-        # Put reference sequences in include.txt so tree run don't break
-        if self.num_included_samples == 0:
-            if config.get("files", {}).get("include"):
-                del config["files"]["include"]
 
 
 class NonContextualizedPlugin(TreeTypePlugin):
-    crowding_penalty = 0.1
+    crowding_penalty = 0
     tree_type = TreeType.NON_CONTEXTUALIZED
     subsampling_scheme = "NON_CONTEXTUALIZED"
 
     def run_type_config(self, config, subsampling):
+        """
+        DATA we can use in this function:
+          config : the entire mega-template data structure, with build configs already updated by BaseNextstrainConfigBuilder.update_build()
+          subsampling : the subsampling scheme for *this build type only* (ex: mega_template["subsampling"]["NON_CONTEXTUALIZED"])
+          self.subsampling_scheme : the value a few lines above
+          self.crowding_penalty : the value a few lines above
+          self.group : information about the group that this run is for (ex: self.group.name or self.group.default_tree_location)
+          self.num_sequences : the number of aspen samples written to our fasta input file
+          self.num_included_samples : the number of samples in include.txt (aspen + gisaid samples) for on-demand runs only
+
+        EXAMPLES SECTION:
+          Delete a group from a subsampling scheme:
+              del subsampling["group"]
+
+          Delete a setting from a group:
+              del subsampling["group"]["max_sequences"]
+
+          Add a group to a subsampling scheme:
+              subsampling["my_new_group_name"] = {
+                  "group_by": "region",
+                  "max_sequences": 200,
+                  "query": '--query "(foo != {bar})"'
+              }
+
+          Add a setting to a group (this is the same as updating an existing setting!):
+              subsampling["group"]["mynewsetting"] = "mynewvalue"
+        """
         # Handle sampling date & pango lineage filters
         apply_filters(config, subsampling, self.template_args)
 
-        # Update our sampling for state/country level builds if necessary
-        update_subsampling_for_location(self.tree_build_level, subsampling)
-
-        # If there aren't any selected samples due to no user selection
-        # Put reference sequences in include.txt so tree run don't break
-        if self.num_included_samples == 0:
-            if config.get("files", {}).get("include"):
-                del config["files"]["include"]
+        # This is a strict target for the number of sequences.
+        subsampling["group"]["max_sequences"] = 1500 * self.crowding_penalty
 
 
-# Set max_sequences for targeted builds.
 class TargetedPlugin(TreeTypePlugin):
     crowding_penalty = 0
     tree_type = TreeType.TARGETED
@@ -181,7 +182,7 @@ class TargetedPlugin(TreeTypePlugin):
     def run_type_config(self, config, subsampling):
         """
         DATA we can use in this function:
-          config : the entire mega-template data structure, with some fields already updated by BaseNextstrainConfigBuilder.update_build()
+          config : the entire mega-template data structure, with build configs already updated by BaseNextstrainConfigBuilder.update_build()
           subsampling : the subsampling scheme for *this build type only* (ex: mega_template["subsampling"]["TARGETED"])
           self.subsampling_scheme : the value a few lines above
           self.crowding_penalty : the value a few lines above
@@ -210,8 +211,33 @@ class TargetedPlugin(TreeTypePlugin):
         closest_max_sequences = 250
         other_max_sequences = 25
         if self.num_included_samples >= 250:
-            closest_max_sequences = self.num_included_samples
-            other_max_sequences = int(ceil(self.num_included_samples / 4.0))
+            # For huge builds, just show the root, the local group, and some
+            # serial-sampling implemented in the subsampling config.
+            closest_max_sequences = 250
+            other_max_sequences = 100
+        elif self.num_included_samples >= 100:
+            closest_max_sequences = 250
+            other_max_sequences = 50
+        elif self.num_included_samples >= 50:
+            closest_max_sequences = 200
+            other_max_sequences = 25
+        elif self.num_included_samples >= 25:
+            closest_max_sequences = 150
+            other_max_sequences = 25
+        elif self.num_included_samples >= 10:
+            closest_max_sequences = 100
+            other_max_sequences = 25
+        else:
+            # Make sure we have enough context to make the tree's structure meaningful
+            closest_max_sequences = 50
+            other_max_sequences = 25
+
+        if self.num_included_samples > 1000:
+            # A large number of samples in include.txt indicates that gisaid might include many nearly-identical samples.
+            # Decrease the number of sequences selected by the "closest" group to improve performance and reduce potential bias from including too many closely related gisaid samples.
+            factor = 1000 / float(self.num_included_samples)
+            closest_max_sequences = int(ceil(closest_max_sequences * factor))
+            other_max_sequences = int(ceil(other_max_sequences * factor))
 
         subsampling["closest"]["max_sequences"] = closest_max_sequences
 
@@ -224,50 +250,39 @@ class TargetedPlugin(TreeTypePlugin):
         subsampling["country"]["max_sequences"] = other_max_sequences
         subsampling["international"]["max_sequences"] = other_max_sequences
 
+        # Handle sampling date and lineage filters for targeted builds
+        apply_filters(config, subsampling, self.template_args)
+
         # Update our sampling for state/country level builds if necessary
         update_subsampling_for_location(self.tree_build_level, subsampling)
 
-        # Increase int'l sequences for state/country builds.
-        if (
-            self.tree_build_level != "location"
-            and subsampling["international"]["max_sequences"] < 100
-        ):
-            subsampling["international"]["max_sequences"] = 100
-
 
 def update_subsampling_for_location(tree_build_level, subsampling):
-    if tree_build_level == "country":
-        update_subsampling_for_country(subsampling)
-    if tree_build_level == "division":
-        update_subsampling_for_division(subsampling)
+    # location "state" means we want this to be a location level build.
+    # we should change the "division" query to use location
+    if tree_build_level == "location":
+        subsampling["group"]["query"] = subsampling["group"]["query"].replace(
+            "division",
+            "location",
+        )
 
+        subsampling["state"]["query"] = subsampling["state"]["query"].replace(
+            "_state",
+            "_location",
+        )
 
-def update_subsampling_for_country(subsampling):
-    # State and country aren't useful
-    if "state" in subsampling:
-        del subsampling["state"]
-    if "country" in subsampling:
+        # state-group is group, country-group becomes state-group
+        subsampling["group"] = subsampling["state"]
+        subsampling["state"] = subsampling["country"]
+
+        # and country-group becomes international
+        subsampling["country"] = subsampling["international"]
+        del subsampling["international"]
+
+    # location division means we are making a division level build, and should omit the
+    # country layer
+    elif tree_build_level == "division":
         del subsampling["country"]
-    # Update our local group query
-    if "--query" in subsampling["group"]["query"]:
-        subsampling["group"]["query"] = '''--query "(country == '{country}')"'''
-    else:
-        subsampling["group"]["query"] = "(country == '{country}')"
-
-
-def update_subsampling_for_division(subsampling):
-    # State isn't useful
-    if "state" in subsampling:
-        del subsampling["state"]
-    # Update our local group query
-    if "--query" in subsampling["group"]["query"]:
-        subsampling["group"][
-            "query"
-        ] = '''--query "(division == '{division}') & (country == '{country}')"'''  # Keep the country filter in case of multiple divisions worldwide
-    else:
-        subsampling["group"][
-            "query"
-        ] = "(division == '{division}') & (country == '{country}')"  # Keep the country filter in case of multiple divisions worldwide
 
 
 def apply_filters(config, subsampling, template_args):
@@ -283,41 +298,53 @@ def apply_filters(config, subsampling, template_args):
     mpox lineage filtering in the future. Once the user has a way to pass those params
     to filter mpox trees using lineage though, it will still be necessary to change
     the config building process here so lineage filter is correctly handled for mpox
-    and integrates with the downstream snakemake workflow that builds the tree."""
+    and integrates with the downstream snakemake workflow that builds the tree.
+    """
+
+    # ---- Date filters ----
     min_date = template_args.get("filter_start_date")
     if min_date:
         # Support date expressions like "5 days ago" in our cron schedule.
         min_date = dateparser.parse(min_date).strftime("%Y-%m-%d")
-        subsampling["group"][
-            "min_date"
-        ] = f"--min-date {min_date}"  # ex: --max-date 2020-01-01
+        subsampling["group"]["min_date"] = f"--min-date {min_date}"
+
     max_date = template_args.get("filter_end_date")
     if max_date:
         # Support date expressions like "5 days ago" in our cron schedule.
         max_date = dateparser.parse(max_date).strftime("%Y-%m-%d")
-        subsampling["group"][
-            "max_date"
-        ] = f"--max-date {max_date}"  # ex: --max-date 2020-01-01
+        subsampling["group"]["max_date"] = f"--max-date {max_date}"
         if "international_serial_sampling" in subsampling:
-            subsampling["international_serial_sampling"][
-                "max_date"
-            ] = f"--max-date {max_date}"  # ex: --max-date 2020-01-01
+            subsampling["international_serial_sampling"]["max_date"] = f"--max-date {max_date}"
 
-    # Only SC2 supports lineage filtering right now. See above note for details.
+    # ---- Lineage filters (SC2 only, extended) ----
     LINEAGE_FIELD = "pango_lineage"
     pango_lineages = template_args.get("filter_pango_lineages")
-    if pango_lineages:
-        # Nextstrain is rather particular about the acceptable syntax for
-        # values in the pango_lineages key. Before modifying please see
-        # https://discussion.nextstrain.org/t/failure-when-specifying-multiple-pango-lineages-in-a-build/670
-        clean_values = [re.sub(r"[^0-9a-zA-Z.]", "", item) for item in pango_lineages]
-        clean_values.sort()
-        config["builds"]["aspen"]["pango_lineage"] = clean_values
-        # Remove the last " from our old query so we can inject more filters
+    if not pango_lineages:
+        return
+
+    # Nextstrain is rather particular about the acceptable syntax for
+    # values in the pango_lineages key. Before modifying please see
+    # https://discussion.nextstrain.org/t/failure-when-specifying-multiple-pango-lineages-in-a-build/670
+    clean_values = [re.sub(r"[^0-9a-zA-Z.]", "", item) for item in pango_lineages]
+    clean_values.sort()
+    config["builds"]["aspen"]["pango_lineage"] = clean_values
+
+    # Build the lineage query fragment
+    lineage_query = f" & ({LINEAGE_FIELD} in {{pango_lineage}})"
+
+    def _add_lineage_to_block(block_name: str) -> None:
+        if block_name not in subsampling:
+            return
+        old_query = subsampling[block_name]["query"]
         end_string = ""
-        old_query = subsampling["group"]["query"]
+        # Preserve any trailing quote, as in the original implementation
         if old_query.endswith('"'):
             end_string = '"'
             old_query = old_query[:-1]
-        pango_query = " & (" + LINEAGE_FIELD + " in {pango_lineage})"
-        subsampling["group"]["query"] = old_query + pango_query + end_string
+        subsampling[block_name]["query"] = old_query + lineage_query + end_string
+
+    # 1) Original behavior: group is lineage-filtered
+    _add_lineage_to_block("group")
+
+    # 2) New behavior: same-lineage context blocks
+    _add_lineage_to_block("international_same_lineage")

--- a/src/backend/aspen/workflows/nextstrain_run/builds_templates/SC2_template.yaml
+++ b/src/backend/aspen/workflows/nextstrain_run/builds_templates/SC2_template.yaml
@@ -77,6 +77,14 @@ subsampling:
       seq_per_group: 2
       query: --query "(country != '{country}')"
 
+    # to always include some sequences outside focal location but within same lineage
+    international_same_lineage:
+      group_by: "region year month"
+      max_sequences: 100
+      query: --query "(country != '{country}')"
+      priorities:
+        type: "proximity"
+        focus: "group"
 
 
   TARGETED:
@@ -128,6 +136,14 @@ subsampling:
       group_by: "region year month"
       seq_per_group: 2
       query: --query "(country != '{country}')"
+
+    international_same_lineage:
+      group_by: "region year month"
+      max_sequences: 50
+      query: --query "(country != '{country}')"
+      priorities:
+        type: "proximity"
+        focus: "focal"
 
 
   NON_CONTEXTUALIZED:


### PR DESCRIPTION
This PR updates the subsampling configuration and lineage-filtering logic so that SC2 builds (overview + targeted) correctly include foreign same-lineage contextual samples (e.g. foreign XFG when focal samples come from Denmark).

Changes
	•	Added international_same_lineage block to SC2 subsampling templates (overview + targeted).
	•	Extended apply_filters() to apply lineage filters to:
	•	group (existing behavior)
	•	international_same_lineage (new behavior)
	•	Updated TargetedPlugin so targeted builds also call apply_filters.

Impact
	•	Fixes missing contextual foreign same-lineage sequences when using GenBank-only backend.
	•	Improves representativeness and interpretability of targeted and overview trees for lineage-specific analyses.

Test
tested by exercising apply_filters on SC2 subsampling config; verified lineage filter applied to group and international_same_lineage for OVERVIEW and TARGETED.”